### PR TITLE
simplify dbconnect() by getting env variables inside the function

### DIFF
--- a/server/config/dbconnect.js
+++ b/server/config/dbconnect.js
@@ -1,17 +1,20 @@
+const path = require('node:path');
+
 require('dotenv').config({
-  path:
+  path: path.join(__dirname,
     process.env.NODE_ENV === 'test'
-      ? '../.env.test.local'
-      : '../.env.development.local',
+      ? '.env.test.local'
+      : '.env.development.local',
+  )
 });
 
-function dbconnect(
-  DB_PROT,
-  DB_SRV,
-  DB_HOST,
-  DB_PORT,
-  DB_NAME
-) {
+const DB_PROT = process.env.DB_PROT;
+const DB_HOST = process.env.DB_HOST;
+const DB_PORT = process.env.DB_PORT;
+const DB_NAME = process.env.DB_NAME;
+const DB_SRV = process.env.DB_SRV;
+
+function dbconnect() {
   if (DB_SRV !== '') {
     return `${DB_PROT}://${DB_SRV}@${DB_PORT}/${DB_NAME}`;
   } else {

--- a/server/models/db.js
+++ b/server/models/db.js
@@ -8,14 +8,8 @@ const mongoose = require('mongoose');
 const dbconnect = require('../config/dbconnect');
 
 
-const DB_PROT = process.env.DB_PROT;
-const DB_HOST = process.env.DB_HOST;
-const DB_PORT = process.env.DB_PORT;
-const DB_NAME = process.env.DB_NAME;
-const DB_SRV = process.env.DB_SRV;
-
 const connectDB = async () => {
-  const URI = dbconnect(DB_PROT, DB_SRV, DB_HOST, DB_PORT, DB_NAME);
+  const URI = dbconnect();
   try {
     await mongoose.connect(URI);
     console.log(`Database connected successfully on ${URI}`);


### PR DESCRIPTION
small refactor: 

because i need to re-use dbconnect() several times, I simplified it by getting the environment variables inside the function, instead of having to import them in each file and passing them as arguments to dbconnect().

Now you can just connect by calling dbconnect() without arguments.